### PR TITLE
Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # `go-vfs`
 
 [![Build Status](https://travis-ci.org/twpayne/go-vfs.svg?branch=master)](https://travis-ci.org/twpayne/go-vfs)
+[![Build status](https://ci.appveyor.com/api/projects/status/m0nup45u310krjah?svg=true)](https://ci.appveyor.com/project/twpayne/go-vfs)
 [![GoDoc](https://godoc.org/github.com/twpayne/go-vfs?status.svg)](https://godoc.org/github.com/twpayne/go-vfs)
 [![Report Card](https://goreportcard.com/badge/github.com/twpayne/go-vfs)](https://goreportcard.com/report/github.com/twpayne/go-vfs)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,11 @@
+version: "{build}"
+clone_folder: c:\gopath\src\github.com\twpayne\go-vfs
+environment:
+  GOPATH: c:\gopath
+install:
+  - go version
+  - go get -t -v ./...
+build_script:
+  - go build
+test_script:
+  - go test -v

--- a/vfst/test_sys_nlink.go
+++ b/vfst/test_sys_nlink.go
@@ -1,0 +1,26 @@
+// +build !windows
+
+package vfst
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/twpayne/go-vfs"
+)
+
+// TestSysNlink returns a PathTest that verifies that the the path's
+// Sys().(*syscall.Stat_t).Nlink is equal to wantNlink. If path's Sys() cannot
+// be converted to a *syscall.Stat_t, it does nothing.
+func TestSysNlink(wantNlink int) PathTest {
+	return func(t *testing.T, fs vfs.FS, path string) {
+		info, err := fs.Lstat(path)
+		if err != nil {
+			t.Errorf("fs.Lstat(%q) == %+v, %v, want !<nil>, <nil>", path, info, err)
+			return
+		}
+		if stat, ok := info.Sys().(*syscall.Stat_t); ok && int(stat.Nlink) != wantNlink {
+			t.Errorf("fs.Lstat(%q).Sys().(*syscall.Stat_t).Nlink == %d, want %d", path, stat.Nlink, wantNlink)
+		}
+	}
+}

--- a/vfst/test_sys_nlink_windows.go
+++ b/vfst/test_sys_nlink_windows.go
@@ -1,0 +1,15 @@
+package vfst
+
+import (
+	"testing"
+
+	"github.com/twpayne/go-vfs"
+)
+
+// TestSysNlink returns a PathTest that verifies that the the path's
+// Sys().(*syscall.Stat_t).Nlink is equal to wantNlink. If path's Sys() cannot
+// be converted to a *syscall.Stat_t, it does nothing.
+func TestSysNlink(wantNlink int) PathTest {
+	return func(*testing.T, vfs.FS, string) {
+	}
+}

--- a/vfst/vfst.go
+++ b/vfst/vfst.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strconv"
-	"syscall"
 	"testing"
 
 	"github.com/twpayne/go-vfs"
@@ -329,22 +328,6 @@ var TestDoesNotExist PathTest = testDoesNotExist
 
 // TestIsDir is a PathTest that verifies that the path is a directory.
 var TestIsDir = TestModeType(os.ModeDir)
-
-// TestSysNlink returns a PathTest that verifies that the the path's
-// Sys().(*syscall.Stat_t).Nlink is equal to wantNlink. If path's Sys() cannot
-// be converted to a *syscall.Stat_t, it does nothing.
-func TestSysNlink(wantNlink int) PathTest {
-	return func(t *testing.T, fs vfs.FS, path string) {
-		info, err := fs.Lstat(path)
-		if err != nil {
-			t.Errorf("fs.Lstat(%q) == %+v, %v, want !<nil>, <nil>", path, info, err)
-			return
-		}
-		if stat, ok := info.Sys().(*syscall.Stat_t); ok && int(stat.Nlink) != wantNlink {
-			t.Errorf("fs.Lstat(%q).Sys().(*syscall.Stat_t).Nlink == %d, want %d", path, stat.Nlink, wantNlink)
-		}
-	}
-}
 
 // TestModePerm returns a PathTest that verifies that the path's permissions
 // are equal to wantPerm.


### PR DESCRIPTION
This PR uses build flags to avoid using `syscall.Stat_t` on Windows systems and adds AppVeyor CI integration.