### PR TITLE
Windows tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # `go-vfs`
 
+[![GoDoc](https://godoc.org/github.com/twpayne/go-vfs?status.svg)](https://godoc.org/github.com/twpayne/go-vfs)
 [![Build Status](https://travis-ci.org/twpayne/go-vfs.svg?branch=master)](https://travis-ci.org/twpayne/go-vfs)
 [![Build status](https://ci.appveyor.com/api/projects/status/m0nup45u310krjah?svg=true)](https://ci.appveyor.com/project/twpayne/go-vfs)
-[![GoDoc](https://godoc.org/github.com/twpayne/go-vfs?status.svg)](https://godoc.org/github.com/twpayne/go-vfs)
 [![Report Card](https://goreportcard.com/badge/github.com/twpayne/go-vfs)](https://goreportcard.com/report/github.com/twpayne/go-vfs)
 
 Package `go-vfs` provides an abstraction of the `os` and `ioutil` packages that

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,4 +8,4 @@ install:
 build_script:
   - go build
 test_script:
-  - go test -v
+  - go test -v ./...

--- a/vfst/fs_test.go
+++ b/vfst/fs_test.go
@@ -21,7 +21,7 @@ func TestWalk(t *testing.T) {
 	}
 	pathTypeMap := make(map[string]os.FileMode)
 	if err := vfs.Walk(fs, "/", func(path string, info os.FileInfo, err error) error {
-		pathTypeMap[path] = info.Mode() & os.ModeType
+		pathTypeMap[filepath.ToSlash(path)] = info.Mode() & os.ModeType
 		if err != nil {
 			t.Errorf("walkFn(%q, %v, %v) called, want err == <nil>", path, info, err)
 		}

--- a/vfst/test.go
+++ b/vfst/test.go
@@ -3,11 +3,18 @@
 package vfst
 
 import (
+	"os"
 	"syscall"
 	"testing"
 
 	"github.com/twpayne/go-vfs"
 )
+
+// permEqual returns if perm1 and perm2 represent the same permissions. On
+// Windows, it always returns true.
+func permEqual(perm1, perm2 os.FileMode) bool {
+	return perm1&os.ModePerm == perm2&os.ModePerm
+}
 
 // TestSysNlink returns a PathTest that verifies that the the path's
 // Sys().(*syscall.Stat_t).Nlink is equal to wantNlink. If path's Sys() cannot

--- a/vfst/test_windows.go
+++ b/vfst/test_windows.go
@@ -1,10 +1,17 @@
 package vfst
 
 import (
+	"os"
 	"testing"
 
 	"github.com/twpayne/go-vfs"
 )
+
+// permEqual returns if perm1 and perm2 represent the same permissions. On
+// Windows, it always returns true.
+func permEqual(perm1, perm2 os.FileMode) bool {
+	return true
+}
 
 // TestSysNlink returns a PathTest that verifies that the the path's
 // Sys().(*syscall.Stat_t).Nlink is equal to wantNlink. If path's Sys() cannot

--- a/vfst/vfst.go
+++ b/vfst/vfst.go
@@ -163,7 +163,7 @@ func (b *Builder) Mkdir(fs vfs.FS, path string, perm os.FileMode) error {
 		return err
 	} else if !info.IsDir() {
 		return fmt.Errorf("%s: not a directory", path)
-	} else if gotPerm, wantPerm := info.Mode()&os.ModePerm, perm&^b.umask; gotPerm != wantPerm {
+	} else if gotPerm, wantPerm := info.Mode()&os.ModePerm, perm&^b.umask; !permEqual(gotPerm, wantPerm) {
 		return fmt.Errorf("%s has permissions 0%o, want 0%o", path, gotPerm, wantPerm)
 	}
 	return nil
@@ -226,7 +226,7 @@ func (b *Builder) WriteFile(fs vfs.FS, path string, contents []byte, perm os.Fil
 		return err
 	} else if !info.Mode().IsRegular() {
 		return fmt.Errorf("%s: not a regular file", path)
-	} else if gotPerm, wantPerm := info.Mode()&os.ModePerm, perm&^b.umask; gotPerm != wantPerm {
+	} else if gotPerm, wantPerm := info.Mode()&os.ModePerm, perm&^b.umask; !permEqual(gotPerm, wantPerm) {
 		return fmt.Errorf("%s has permissions 0%o, want 0%o", path, gotPerm, wantPerm)
 	} else {
 		gotContents, err := fs.ReadFile(path)
@@ -338,7 +338,7 @@ func TestModePerm(wantPerm os.FileMode) PathTest {
 			t.Errorf("fs.Lstat(%q) == %+v, %v, want !<nil>, <nil>", path, info, err)
 			return
 		}
-		if gotPerm := info.Mode() & os.ModePerm; gotPerm != wantPerm {
+		if gotPerm := info.Mode() & os.ModePerm; !permEqual(gotPerm, wantPerm) {
 			t.Errorf("fs.Lstat(%q).Mode()&os.ModePerm == 0%o, want 0%o", path, gotPerm, wantPerm)
 		}
 	}

--- a/vfst/vfst_test.go
+++ b/vfst/vfst_test.go
@@ -1,6 +1,7 @@
 package vfst
 
 import (
+	"errors"
 	"log"
 	"os"
 	"testing"
@@ -162,11 +163,15 @@ func TestCoverage(t *testing.T) {
 }
 
 func TestErrors(t *testing.T) {
+	errSkip := errors.New("skip")
 	for name, f := range map[string]func(*Builder, vfs.FS) error{
 		"write_file_with_different_content": func(b *Builder, fs vfs.FS) error {
 			return b.WriteFile(fs, "/home/user/.bashrc", nil, 0644)
 		},
 		"write_file_with_different_perms": func(b *Builder, fs vfs.FS) error {
+			if permEqual(0644, 0755) {
+				return errSkip
+			}
 			return b.WriteFile(fs, "/home/user/.bashrc", []byte("# bashrc\n"), 0755)
 		},
 		"write_file_to_existing_dir": func(b *Builder, fs vfs.FS) error {
@@ -182,6 +187,9 @@ func TestErrors(t *testing.T) {
 			return b.WriteFile(fs, "/home/user/symlink/foo", nil, 0644)
 		},
 		"mkdir_existing_dir_with_different_perms": func(b *Builder, fs vfs.FS) error {
+			if permEqual(0755, 0666) {
+				return errSkip
+			}
 			return b.Mkdir(fs, "/home/user", 0666)
 		},
 		"mkdir_to_existing_file": func(b *Builder, fs vfs.FS) error {


### PR DESCRIPTION
This PR makes `go-vfs` build and pass tests on Windows. Permissions are ignored.