### PR TITLE
Improve Windows support

### DIFF
--- a/contains.go
+++ b/contains.go
@@ -56,6 +56,10 @@ func Contains(fs Stater, p, prefix string) (bool, error) {
 					goto TryParent
 				case syscall.EOVERFLOW:
 					goto TryParent
+				default:
+					if shouldSkipSystemError(errno) {
+						goto TryParent
+					}
 				}
 			}
 			return false, err

--- a/contains_other.go
+++ b/contains_other.go
@@ -1,0 +1,9 @@
+// +build !windows
+
+package vfs
+
+import "syscall"
+
+func shouldSkipSystemError(err syscall.Errno) bool {
+	return false
+}

--- a/contains_windows.go
+++ b/contains_windows.go
@@ -1,0 +1,14 @@
+// +build windows
+
+package vfs
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// return true if the error should be skipped, false otherwise
+func shouldSkipSystemError(err syscall.Errno) bool {
+	return err == windows.ERROR_CANT_RESOLVE_FILENAME
+}

--- a/mkdirall.go
+++ b/mkdirall.go
@@ -46,7 +46,7 @@ func MkdirAll(fs MkdirStater, path string, perm os.FileMode) error {
 			return err
 		}
 		if err := MkdirAll(fs, parentDir, perm); err != nil {
-			return nil
+			return err
 		}
 		return fs.Mkdir(path, perm)
 	default:

--- a/path_fs.go
+++ b/path_fs.go
@@ -215,9 +215,14 @@ func (p *PathFS) WriteFile(filename string, data []byte, perm os.FileMode) error
 	return p.fs.WriteFile(realFilename, data, perm)
 }
 
-// join returns p's path joined with name.
+// join returns p's path joined with name. incoming path names
+// should always use / as a separator, while outgoing paths
+// should use the appropriate separator for the current path
+// mainly because on Windows paths without a volume specifier
+// are never absolute, meaning that this check will always fail
 func (p *PathFS) join(op string, name string) (string, error) {
-	if !filepath.IsAbs(name) {
+	name = filepath.ToSlash(name)
+	if !path.IsAbs(name) {
 		return "", &os.PathError{
 			Op:   op,
 			Path: name,

--- a/vfst/contains_test.go
+++ b/vfst/contains_test.go
@@ -1,6 +1,7 @@
 package vfst
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 
@@ -109,9 +110,13 @@ func TestContains(t *testing.T) {
 		},
 		{
 			name: "symlink_dir",
-			root: map[string]interface{}{
-				"/home/user/file": "contents",
-				"/home/symlink":   &Symlink{Target: "user"},
+			root: []interface{}{
+				map[string]interface{}{
+					"/home/user/file": "contents",
+				},
+				map[string]interface{}{
+					"/home/symlink": &Symlink{Target: "user"},
+				},
 			},
 			tests: []test{
 				{
@@ -194,6 +199,9 @@ func TestContains(t *testing.T) {
 				},
 			},
 		},
+
+		// Windows has a maximum path length of 260 chars ( - 12 if creating a directory)
+		// so these tests are expected to error out on that platform.
 		{
 			name: "long_filename",
 			root: map[string]interface{}{
@@ -201,19 +209,22 @@ func TestContains(t *testing.T) {
 			},
 			tests: []test{
 				{
-					p:        "/home/user/" + strings.Repeat("filename", 1024*1024), // 8MB filename
-					prefix:   "/home/user",
-					expected: true,
+					p:         "/home/user/" + strings.Repeat("filename", 1024*1024), // 8MB filename
+					prefix:    "/home/user",
+					expectErr: runtime.GOOS == "windows",
+					expected:  true,
 				},
 				{
-					p:        "/home/user/" + strings.Repeat("filename", 1024*1024), // 8MB filename
-					prefix:   "/home",
-					expected: true,
+					p:         "/home/user/" + strings.Repeat("filename", 1024*1024), // 8MB filename
+					prefix:    "/home",
+					expectErr: runtime.GOOS == "windows",
+					expected:  true,
 				},
 				{
-					p:        "/home/user/" + strings.Repeat("filename", 1024*1024), // 8MB filename
-					prefix:   "/",
-					expected: true,
+					p:         "/home/user/" + strings.Repeat("filename", 1024*1024), // 8MB filename
+					prefix:    "/",
+					expectErr: runtime.GOOS == "windows",
+					expected:  true,
 				},
 			},
 		},

--- a/vfst/vfst.go
+++ b/vfst/vfst.go
@@ -80,6 +80,14 @@ func NewBuilder(options ...BuilderOption) *Builder {
 // build is a recursive helper for Build.
 func (b *Builder) build(fs vfs.FS, path string, i interface{}) error {
 	switch i := i.(type) {
+	case []interface{}:
+		for _, element := range i {
+			if err := b.build(fs, path, element); err != nil {
+				return err
+			}
+		}
+		return nil
+
 	case *Dir:
 		if parentDir := filepath.Dir(path); parentDir != "." {
 			if err := b.MkdirAll(fs, parentDir, 0777); err != nil {

--- a/vfst/vfst_test.go
+++ b/vfst/vfst_test.go
@@ -257,11 +257,15 @@ func TestErrors(t *testing.T) {
 			}
 			defer cleanup()
 			b := NewBuilder(BuilderVerbose(true))
-			root := map[string]interface{}{
-				"/home/user/.bashrc": "# bashrc\n",
-				"/home/user/empty":   []byte{},
-				"/home/user/symlink": &Symlink{Target: "empty"},
-				"/home/user/foo":     &Dir{Perm: 0755},
+			root := []interface{}{
+				map[string]interface{}{
+					"/home/user/.bashrc": "# bashrc\n",
+					"/home/user/empty":   []byte{},
+					"/home/user/foo":     &Dir{Perm: 0755},
+				},
+				map[string]interface{}{
+					"/home/user/symlink": &Symlink{Target: "empty"},
+				},
 			}
 			if err := b.Build(fs, root); err != nil {
 				t.Fatalf("b.Build(fs, root) == %v, want <nil>", err)


### PR DESCRIPTION
Fixes twpayne/go-vfs#25.  More discussion is available there.

 Notable changes:
 * Contans(): fs.Stat can return a Windows-specific errno that should be ignored (ERROR_CANT_RESOLVE_FILENAME)
  * vfst: On Windows, symlinks should not be created before the things they point to exist (because links to directories are different from links to files, and the difference must be explicitly specified when calling CreateSymbolicLink).  Since maps can't be guaranteed to iterate in any particular order, add support for passing a Builder a list of any of the types already supported, so that order is guaranteed.
  * contains_test: Path names on Windows may not be longer than ~260 characters (some tools and APIs support 32K chars, but not all), so on that platform the long_filename tests are expected to fail.
  * MkdirAll(): When Windows is asked to make a directory containing a path component that exists but is not a directory, the Windows APIs return (the equivalent of) ENOENT rather than ENOTDIR.  This causes MkdirAll() to attempt to recursively create the path, which will fail because it already exists.  This is detected correctly but MkdirAll was swallowing the error, causing the test to detect no error when one was expected.