### PR TITLE
Add WindowsOSFS, HostOSFS, and Windows CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ The implementations of `FS` provided are:
 
 * `ReadOnlyFS` which prevents modification of the underlying FS.
 
+* `WindowsOSFS` which overrides `Chmod` to work on Windows.
+
+* `HostOSFS` which is `WindowsOSFS` on Windows, `OSFS` elsewhere.
+
 * `TestFS` which assists running tests on a real filesystem but in a temporary
    directory that is easily cleaned up.
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The implementations of `FS` provided are:
 * `HostOSFS` which is `WindowsOSFS` on Windows, `OSFS` elsewhere.
 
 * `TestFS` which assists running tests on a real filesystem but in a temporary
-   directory that is easily cleaned up.
+   directory that is easily cleaned up. It uses `HostOSFS` under the hood.
 
 Example usage:
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![GoDoc](https://godoc.org/github.com/twpayne/go-vfs?status.svg)](https://godoc.org/github.com/twpayne/go-vfs)
 [![Build Status](https://travis-ci.org/twpayne/go-vfs.svg?branch=master)](https://travis-ci.org/twpayne/go-vfs)
+[![Build status](https://ci.appveyor.com/api/projects/status/v53b59r5iivoadyr/branch/master?svg=true)](https://ci.appveyor.com/project/twpayne/go-vfs/branch/master)
 [![Report Card](https://goreportcard.com/badge/github.com/twpayne/go-vfs)](https://goreportcard.com/report/github.com/twpayne/go-vfs)
 [![Coverage Status](https://coveralls.io/repos/github/twpayne/go-vfs/badge.svg)](https://coveralls.io/github/twpayne/go-vfs)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,12 @@
+version: "{build}"
+clone_folder: c:\gopath\src\github.com\twpayne\go-vfs
+environment:
+  GO111MODULE: on
+  GOPATH: c:\gopath
+install:
+  - go version
+  - go mod download
+build_script:
+  - go build
+test_script:
+  - go test ./...

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/twpayne/go-vfs
 go 1.12
 
 require (
+	github.com/hectane/go-acl v0.0.0-20190523051433-dfeb47f3e2ef
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/sys v0.0.0-20190523142557-0e01d883c5c5
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/hectane/go-acl v0.0.0-20190523051433-dfeb47f3e2ef h1:kKfJP3gHIuNfCZdSAbtKjDpkBwVnXh/SVMtxHourrDE=
+github.com/hectane/go-acl v0.0.0-20190523051433-dfeb47f3e2ef/go.mod h1:xk/21OELzVCkl0NZCoB+eLISXe1p+YDiha8WaQDD1d8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/hostosfs_posix.go
+++ b/hostosfs_posix.go
@@ -1,0 +1,6 @@
+//+build !windows
+
+package vfs
+
+// HostOSFS is the host-specific OSFS.
+var HostOSFS = OSFS

--- a/hostosfs_windows.go
+++ b/hostosfs_windows.go
@@ -1,0 +1,20 @@
+//+build windows
+
+package vfs
+
+import (
+	"os"
+
+	acl "github.com/hectane/go-acl"
+)
+
+// HostOSFS is the host-specific OSFS.
+var HostOSFS = WindowsOSFS{}
+
+type WindowsOSFS struct {
+	osfs
+}
+
+func (WindowsOSFS) Chmod(name string, mode os.FileMode) error {
+	return acl.Chmod(name, mode)
+}

--- a/vfst/testfs.go
+++ b/vfst/testfs.go
@@ -20,7 +20,7 @@ func newTestFS() (*TestFS, func(), error) {
 		return nil, nil, err
 	}
 	t := &TestFS{
-		PathFS:  *vfs.NewPathFS(vfs.OSFS, tempDir),
+		PathFS:  *vfs.NewPathFS(vfs.HostOSFS, tempDir),
 		tempDir: tempDir,
 		keep:    false,
 	}

--- a/windowsosfs_test.go
+++ b/windowsosfs_test.go
@@ -1,0 +1,5 @@
+//+build windows
+
+package vfs
+
+var _ FS = WindowsOSFS{}


### PR DESCRIPTION
This PR adds:

* `WindowsOSFS` to patch `os.Chmod` behavior on Windows.
* `HostOSFS`, which evaluates to a `WindowsOSFS` instance on Windows, and `OSFS` elsewhere.
* `NewTestFS` uses `HostOSFS` by default, instead of `OSFS`.
* Windows CI integration via Appveyor.

cc @zb140.