### PR TITLE
Windows-specific WriteFile

### DIFF
--- a/hostosfs_windows.go
+++ b/hostosfs_windows.go
@@ -3,6 +3,7 @@
 package vfs
 
 import (
+	"io/ioutil"
 	"os"
 
 	acl "github.com/hectane/go-acl"
@@ -15,6 +16,15 @@ type WindowsOSFS struct {
 	osfs
 }
 
-func (WindowsOSFS) Chmod(name string, mode os.FileMode) error {
-	return acl.Chmod(name, mode)
+func (WindowsOSFS) Chmod(name string, fileMode os.FileMode) error {
+    return acl.Chmod(name, fileMode)
+}
+
+// WriteFile implements ioutil.WriteFile.
+func (fs WindowsOSFS) WriteFile(filename string, data []byte, perm os.FileMode) error {
+    err := ioutil.WriteFile(filename, data, perm)
+    if err != nil {
+        return err
+    }
+    return fs.Chmod(filename, perm)
 }

--- a/hostosfs_windows.go
+++ b/hostosfs_windows.go
@@ -16,8 +16,8 @@ type WindowsOSFS struct {
 	osfs
 }
 
-func (WindowsOSFS) Chmod(name string, fileMode os.FileMode) error {
-	return acl.Chmod(name, fileMode)
+func (WindowsOSFS) Chmod(name string, mode os.FileMode) error {
+	return acl.Chmod(name, mode)
 }
 
 // WriteFile implements ioutil.WriteFile.

--- a/hostosfs_windows.go
+++ b/hostosfs_windows.go
@@ -17,14 +17,14 @@ type WindowsOSFS struct {
 }
 
 func (WindowsOSFS) Chmod(name string, fileMode os.FileMode) error {
-    return acl.Chmod(name, fileMode)
+	return acl.Chmod(name, fileMode)
 }
 
 // WriteFile implements ioutil.WriteFile.
 func (fs WindowsOSFS) WriteFile(filename string, data []byte, perm os.FileMode) error {
-    err := ioutil.WriteFile(filename, data, perm)
-    if err != nil {
-        return err
-    }
-    return fs.Chmod(filename, perm)
+	err := ioutil.WriteFile(filename, data, perm)
+	if err != nil {
+		return err
+	}
+	return fs.Chmod(filename, perm)
 }

--- a/pathfs.go
+++ b/pathfs.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -220,6 +221,8 @@ func (p *PathFS) WriteFile(filename string, data []byte, perm os.FileMode) error
 // for the current path mainly because on Windows paths without a volume
 // specifier are never absolute, meaning that this check will always fail.
 func (p *PathFS) join(op string, name string) (string, error) {
+    // remove any volume names before appending the prefix
+    name = strings.Replace(name, filepath.VolumeName(name), "", 1)
 	name = filepath.ToSlash(name)
 	if !path.IsAbs(name) {
 		return "", &os.PathError{

--- a/pathfs.go
+++ b/pathfs.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 )
@@ -222,7 +221,10 @@ func (p *PathFS) WriteFile(filename string, data []byte, perm os.FileMode) error
 // specifier are never absolute, meaning that this check will always fail.
 func (p *PathFS) join(op string, name string) (string, error) {
 	// remove any volume names before appending the prefix
-	name = strings.Replace(name, filepath.VolumeName(name), "", 1)
+	if volumeName := filepath.VolumeName(name); volumeName != "" {
+		name = name[len(volumeName):]
+	}
+
 	name = filepath.ToSlash(name)
 	if !path.IsAbs(name) {
 		return "", &os.PathError{

--- a/pathfs.go
+++ b/pathfs.go
@@ -221,8 +221,8 @@ func (p *PathFS) WriteFile(filename string, data []byte, perm os.FileMode) error
 // for the current path mainly because on Windows paths without a volume
 // specifier are never absolute, meaning that this check will always fail.
 func (p *PathFS) join(op string, name string) (string, error) {
-    // remove any volume names before appending the prefix
-    name = strings.Replace(name, filepath.VolumeName(name), "", 1)
+	// remove any volume names before appending the prefix
+	name = strings.Replace(name, filepath.VolumeName(name), "", 1)
 	name = filepath.ToSlash(name)
 	if !path.IsAbs(name) {
 		return "", &os.PathError{


### PR DESCRIPTION
Add a WindowsOSFS override for WriteFile that ensures permissions are set correctly (using the Chmod override), since ioutil.WriteFile doesn't know about ACLs.

Also remove leading volume specifiers in PathFS when joining with the prefix dir.