### PR TITLE
Fix PathFS.Glob for Windows

### DIFF
--- a/pathfs.go
+++ b/pathfs.go
@@ -73,7 +73,16 @@ func (p *PathFS) Glob(pattern string) ([]string, error) {
 		return nil, err
 	}
 	for i, match := range matches {
-		matches[i] = strings.TrimPrefix(match, p.path)
+		// even on Windows, PathFS uses /-separated paths, so this
+		// TrimPrefix wouldn't remove anything without this conversion
+		// Also, Glob is expected to return absolute paths, which on Windows
+		// must contain a volume specifier, so use filepath.Abs to add one
+		newpath, err := filepath.Abs(strings.TrimPrefix(filepath.ToSlash(match), p.path))
+		if err != nil {
+			return nil, err
+		}
+
+		matches[i] = newpath
 	}
 	return matches, nil
 }


### PR DESCRIPTION
  * PathFS uses /-delimited paths even on Windows, so the TrimPrefix wasn't actually removing the prefix.
  * Also make sure the matches returned by Glob are absolute paths