### PR TITLE
Change trimPrefix to return paths with the host's path separator.

### DIFF
--- a/vfst/vfst_test.go
+++ b/vfst/vfst_test.go
@@ -287,26 +287,26 @@ func TestGlob(t *testing.T) {
 			name:    "all",
 			pattern: "/home/user/*",
 			expectedMatches: []string{
-				"/home/user/.bash_profile",
-				"/home/user/.bashrc",
-				"/home/user/.zshrc",
+				filepath.FromSlash("/home/user/.bash_profile"),
+				filepath.FromSlash("/home/user/.bashrc"),
+				filepath.FromSlash("/home/user/.zshrc"),
 			},
 		},
 		{
 			name:    "star_rc",
 			pattern: "/home/user/*rc",
 			expectedMatches: []string{
-				"/home/user/.bashrc",
-				"/home/user/.zshrc",
+				filepath.FromSlash("/home/user/.bashrc"),
+				filepath.FromSlash("/home/user/.zshrc"),
 			},
 		},
 		{
 			name:    "all_subdir",
 			pattern: "/home/*/*",
 			expectedMatches: []string{
-				"/home/user/.bash_profile",
-				"/home/user/.bashrc",
-				"/home/user/.zshrc",
+				filepath.FromSlash("/home/user/.bash_profile"),
+				filepath.FromSlash("/home/user/.bashrc"),
+				filepath.FromSlash("/home/user/.zshrc"),
 			},
 		},
 	} {

--- a/windows.go
+++ b/windows.go
@@ -22,8 +22,9 @@ var ignoreErrnoInContains = map[syscall.Errno]struct{}{
 	windows.ERROR_CANT_RESOLVE_FILENAME: {},
 }
 
-// relativizePath, on Windows, strips any leading volume name from path and
-// replaces backslashes with slashes.
+// relativizePath, on Windows, strips any leading volume name from path.
+// since this is used to prepare paths to have the prefix prepended,
+// returned values use slashes instead of backslashes.
 func relativizePath(path string) string {
 	if volumeName := filepath.VolumeName(path); volumeName != "" {
 		path = path[len(volumeName):]
@@ -33,10 +34,12 @@ func relativizePath(path string) string {
 
 // trimPrefix, on Windows, trims prefix from path and returns an absolute path.
 // prefix must be a /-separated path.
+// since this is used to prepare results to be returned to the calling client,
+// returned values use backslashes instead of slashes
 func trimPrefix(path, prefix string) (string, error) {
 	trimmedPath, err := filepath.Abs(strings.TrimPrefix(filepath.ToSlash(path), prefix))
 	if err != nil {
 		return "", err
 	}
-	return filepath.ToSlash(trimmedPath), nil
+	return filepath.FromSlash(trimmedPath), nil
 }


### PR DESCRIPTION
Also update the tests to match.