### PR TITLE
Fix link to bmatcuk/doublestar

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ easy to test.
   documentation](https://godoc.org/github.com/twpayne/go-vfs/vfst#pkg-examples).
 
 * Compatibility with
-  [`github.com/bmatcuk/doublestar`](github.com/bmatcuk/doublestar),
+  [`github.com/bmatcuk/doublestar`](https://github.com/bmatcuk/doublestar),
   [`github.com/spf13/afero`](https://github.com/spf13/afero) and
   [`github.com/src-d/go-billy`](https://github.com/src-d/go-billy).
 


### PR DESCRIPTION
Without the `https://` prefix, the link points to https://github.com/twpayne/go-vfs/blob/master/github.com/bmatcuk/doublestar.